### PR TITLE
Refactor: Streamline HomeScreen UI and ViewModel

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -5,9 +5,6 @@
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
       </SelectionState>
-      <SelectionState runConfigName="ChaosEntryCardPreview">
-        <option name="selectionMode" value="DROPDOWN" />
-      </SelectionState>
       <SelectionState runConfigName="ChaosEntryCardCollapsedPreview">
         <option name="selectionMode" value="DROPDOWN" />
       </SelectionState>
@@ -18,6 +15,9 @@
         <option name="selectionMode" value="DROPDOWN" />
       </SelectionState>
       <SelectionState runConfigName="MainActivity">
+        <option name="selectionMode" value="DROPDOWN" />
+      </SelectionState>
+      <SelectionState runConfigName="MainActivity (1)">
         <option name="selectionMode" value="DROPDOWN" />
       </SelectionState>
     </selectionStates>

--- a/app/src/main/java/com/dailychaos/project/presentation/ui/component/MainNavigationScreen.kt
+++ b/app/src/main/java/com/dailychaos/project/presentation/ui/component/MainNavigationScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.*
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -13,9 +14,9 @@ import androidx.navigation.compose.rememberNavController
 import com.dailychaos.project.presentation.ui.screen.home.HomeScreen
 
 /**
- * Main Navigation Screen Component - Updated
+ * Main Navigation Screen - Clean Design tanpa FAB
  *
- * "Screen utama yang mengatur navigation dan bottom bar dengan HomeScreen yang proper"
+ * "Navigation yang clean dengan fokus pada bottom navigation bar"
  */
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -27,9 +28,6 @@ fun MainNavigationScreen(
 ) {
     val navBackStackEntry by navController.currentBackStackEntryAsState()
     val currentRoute = navBackStackEntry?.destination?.route
-
-    // State untuk FAB menu
-    var isFabExpanded by remember { mutableStateOf(false) }
 
     Scaffold(
         modifier = modifier.fillMaxSize(),
@@ -48,20 +46,6 @@ fun MainNavigationScreen(
                 }
             )
         },
-        floatingActionButton = {
-            FloatingActionMenu(
-                isExpanded = isFabExpanded,
-                onToggle = { isFabExpanded = !isFabExpanded },
-                onNewChaosEntry = {
-                    isFabExpanded = false
-                    navController.navigate("create_chaos")
-                },
-                onShareToCommunity = {
-                    isFabExpanded = false
-                    navController.navigate("community")
-                }
-            )
-        },
         containerColor = MaterialTheme.colorScheme.background
     ) { paddingValues ->
 
@@ -70,7 +54,7 @@ fun MainNavigationScreen(
             startDestination = "home",
             modifier = Modifier.padding(paddingValues)
         ) {
-            // Home Screen - Updated with proper implementation
+            // Home Screen
             composable("home") {
                 HomeScreen(
                     onNavigateToCreateChaos = {
@@ -209,7 +193,7 @@ fun MainNavigationScreen(
     }
 }
 
-// Placeholder content components - akan diganti dengan actual screens nanti
+// Placeholder content components
 @Composable
 private fun JournalScreenContent(
     onNavigateToCreateChaos: () -> Unit,
@@ -220,13 +204,17 @@ private fun JournalScreenContent(
         contentAlignment = Alignment.Center
     ) {
         Column(
-            horizontalAlignment = Alignment.CenterHorizontally
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(16.dp)
         ) {
             Text(
-                text = "📝 Journal Screen",
+                text = "📝",
+                fontSize = 48.sp
+            )
+            Text(
+                text = "Journal Screen",
                 style = MaterialTheme.typography.headlineMedium
             )
-            Spacer(modifier = Modifier.height(16.dp))
             Button(onClick = onNavigateToCreateChaos) {
                 Text("Add New Entry")
             }
@@ -244,13 +232,17 @@ private fun CommunityScreenContent(
         contentAlignment = Alignment.Center
     ) {
         Column(
-            horizontalAlignment = Alignment.CenterHorizontally
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(16.dp)
         ) {
             Text(
-                text = "🤝 Community Screen",
+                text = "🤝",
+                fontSize = 48.sp
+            )
+            Text(
+                text = "Community Screen",
                 style = MaterialTheme.typography.headlineMedium
             )
-            Spacer(modifier = Modifier.height(16.dp))
             Button(onClick = onNavigateToTwins) {
                 Text("Find Chaos Twins")
             }
@@ -268,13 +260,17 @@ private fun ProfileScreenContent(
         contentAlignment = Alignment.Center
     ) {
         Column(
-            horizontalAlignment = Alignment.CenterHorizontally
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(16.dp)
         ) {
             Text(
-                text = "👤 Profile Screen",
+                text = "👤",
+                fontSize = 48.sp
+            )
+            Text(
+                text = "Profile Screen",
                 style = MaterialTheme.typography.headlineMedium
             )
-            Spacer(modifier = Modifier.height(16.dp))
             Button(onClick = onNavigateToSettings) {
                 Text("Settings")
             }
@@ -292,18 +288,23 @@ private fun CreateChaosScreenContent(
         contentAlignment = Alignment.Center
     ) {
         Column(
-            horizontalAlignment = Alignment.CenterHorizontally
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(16.dp)
         ) {
             Text(
-                text = "✍️ Create Chaos Entry",
+                text = "✍️",
+                fontSize = 48.sp
+            )
+            Text(
+                text = "Create Chaos Entry",
                 style = MaterialTheme.typography.headlineMedium
             )
-            Spacer(modifier = Modifier.height(16.dp))
-            Row {
-                Button(onClick = onNavigateBack) {
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                OutlinedButton(onClick = onNavigateBack) {
                     Text("Cancel")
                 }
-                Spacer(modifier = Modifier.width(8.dp))
                 Button(onClick = onChaosSaved) {
                     Text("Save")
                 }
@@ -323,22 +324,27 @@ private fun ChaosDetailScreenContent(
         contentAlignment = Alignment.Center
     ) {
         Column(
-            horizontalAlignment = Alignment.CenterHorizontally
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(16.dp)
         ) {
             Text(
-                text = "📖 Chaos Entry Detail",
+                text = "📖",
+                fontSize = 48.sp
+            )
+            Text(
+                text = "Chaos Entry Detail",
                 style = MaterialTheme.typography.headlineMedium
             )
             Text(
                 text = "Entry ID: $entryId",
                 style = MaterialTheme.typography.bodyMedium
             )
-            Spacer(modifier = Modifier.height(16.dp))
-            Row {
-                Button(onClick = onNavigateBack) {
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                OutlinedButton(onClick = onNavigateBack) {
                     Text("Back")
                 }
-                Spacer(modifier = Modifier.width(8.dp))
                 Button(onClick = onNavigateToEdit) {
                     Text("Edit")
                 }
@@ -358,22 +364,27 @@ private fun EditChaosScreenContent(
         contentAlignment = Alignment.Center
     ) {
         Column(
-            horizontalAlignment = Alignment.CenterHorizontally
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(16.dp)
         ) {
             Text(
-                text = "✏️ Edit Chaos Entry",
+                text = "✏️",
+                fontSize = 48.sp
+            )
+            Text(
+                text = "Edit Chaos Entry",
                 style = MaterialTheme.typography.headlineMedium
             )
             Text(
                 text = "Editing Entry: $entryId",
                 style = MaterialTheme.typography.bodyMedium
             )
-            Spacer(modifier = Modifier.height(16.dp))
-            Row {
-                Button(onClick = onNavigateBack) {
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                OutlinedButton(onClick = onNavigateBack) {
                     Text("Cancel")
                 }
-                Spacer(modifier = Modifier.width(8.dp))
                 Button(onClick = onChaosSaved) {
                     Text("Save Changes")
                 }
@@ -392,13 +403,17 @@ private fun ChaosHistoryScreenContent(
         contentAlignment = Alignment.Center
     ) {
         Column(
-            horizontalAlignment = Alignment.CenterHorizontally
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(16.dp)
         ) {
             Text(
-                text = "📚 Chaos History",
+                text = "📚",
+                fontSize = 48.sp
+            )
+            Text(
+                text = "Chaos History",
                 style = MaterialTheme.typography.headlineMedium
             )
-            Spacer(modifier = Modifier.height(16.dp))
             Button(onClick = onNavigateBack) {
                 Text("Back")
             }
@@ -416,17 +431,21 @@ private fun CommunityPostDetailContent(
         contentAlignment = Alignment.Center
     ) {
         Column(
-            horizontalAlignment = Alignment.CenterHorizontally
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(16.dp)
         ) {
             Text(
-                text = "💬 Community Post",
+                text = "💬",
+                fontSize = 48.sp
+            )
+            Text(
+                text = "Community Post",
                 style = MaterialTheme.typography.headlineMedium
             )
             Text(
                 text = "Post ID: $postId",
                 style = MaterialTheme.typography.bodyMedium
             )
-            Spacer(modifier = Modifier.height(16.dp))
             Button(onClick = onNavigateBack) {
                 Text("Back")
             }
@@ -444,13 +463,17 @@ private fun ChaosTwinsScreenContent(
         contentAlignment = Alignment.Center
     ) {
         Column(
-            horizontalAlignment = Alignment.CenterHorizontally
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(16.dp)
         ) {
             Text(
-                text = "🤝 Chaos Twins",
+                text = "🤝",
+                fontSize = 48.sp
+            )
+            Text(
+                text = "Chaos Twins",
                 style = MaterialTheme.typography.headlineMedium
             )
-            Spacer(modifier = Modifier.height(16.dp))
             Button(onClick = onNavigateBack) {
                 Text("Back")
             }
@@ -467,13 +490,17 @@ private fun SettingsScreenContent(
         contentAlignment = Alignment.Center
     ) {
         Column(
-            horizontalAlignment = Alignment.CenterHorizontally
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(16.dp)
         ) {
             Text(
-                text = "⚙️ Settings",
+                text = "⚙️",
+                fontSize = 48.sp
+            )
+            Text(
+                text = "Settings",
                 style = MaterialTheme.typography.headlineMedium
             )
-            Spacer(modifier = Modifier.height(16.dp))
             Button(onClick = onNavigateBack) {
                 Text("Back")
             }

--- a/app/src/main/java/com/dailychaos/project/presentation/ui/screen/home/HomeViewModel.kt
+++ b/app/src/main/java/com/dailychaos/project/presentation/ui/screen/home/HomeViewModel.kt
@@ -2,10 +2,7 @@ package com.dailychaos.project.presentation.ui.screen.home
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.dailychaos.project.domain.model.ChaosEntry
-import com.dailychaos.project.domain.model.User
 import com.dailychaos.project.util.KonoSubaQuotes
-import com.dailychaos.project.util.Resource
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
@@ -13,7 +10,7 @@ import kotlinx.datetime.Clock
 import javax.inject.Inject
 
 /**
- * Home ViewModel
+ * Home ViewModel - Clean Architecture
  *
  * "ViewModel untuk Home Screen - seperti guild master yang manage semua quest!"
  */
@@ -42,19 +39,19 @@ class HomeViewModel @Inject constructor(
             is HomeUiEvent.RetryLoadingStats -> loadTodayStats()
             is HomeUiEvent.ClearError -> clearError()
             is HomeUiEvent.NavigateToEntry -> {
-                // TODO: Handle navigation to entry detail
+                // Navigation handled by UI
             }
             is HomeUiEvent.NavigateToCreateChaos -> {
-                // TODO: Handle navigation to create chaos
+                // Navigation handled by UI
             }
             is HomeUiEvent.NavigateToHistory -> {
-                // TODO: Handle navigation to history
+                // Navigation handled by UI
             }
             is HomeUiEvent.NavigateToCommunity -> {
-                // TODO: Handle navigation to community
+                // Navigation handled by UI
             }
             is HomeUiEvent.NavigateToProfile -> {
-                // TODO: Handle navigation to profile
+                // Navigation handled by UI
             }
             is HomeUiEvent.ShareEntry -> shareEntry(event.entryId)
             is HomeUiEvent.ToggleFavoriteEntry -> toggleFavoriteEntry(event.entryId)
@@ -115,7 +112,11 @@ class HomeViewModel @Inject constructor(
 
             try {
                 // TODO: Replace with actual use case
-                val mockUser = getMockUser()
+                // val user = getCurrentUserUseCase()
+
+                // Temporary mock data for development
+                val mockUser = createMockUser()
+
                 _uiState.update {
                     it.copy(
                         user = mockUser,
@@ -139,7 +140,11 @@ class HomeViewModel @Inject constructor(
 
             try {
                 // TODO: Replace with actual use case
-                val mockStats = getMockTodayStats()
+                // val stats = getUserStatsUseCase.getTodayStats()
+
+                // Temporary mock data for development
+                val mockStats = createMockTodayStats()
+
                 _uiState.update {
                     it.copy(
                         todayStats = mockStats,
@@ -163,7 +168,11 @@ class HomeViewModel @Inject constructor(
 
             try {
                 // TODO: Replace with actual use case
-                val mockEntries = getMockRecentEntries()
+                // val entries = getChaosEntriesUseCase.getRecent(limit = 5)
+
+                // Temporary mock data for development
+                val mockEntries = createMockRecentEntries()
+
                 _uiState.update {
                     it.copy(
                         recentEntries = mockEntries,
@@ -187,7 +196,11 @@ class HomeViewModel @Inject constructor(
 
             try {
                 // TODO: Replace with actual use case
-                val mockAchievements = getMockAchievements()
+                // val achievements = getAchievementsUseCase()
+                // val streak = getUserStatsUseCase.getCurrentStreak()
+
+                // Temporary mock data for development
+                val mockAchievements = createMockAchievements()
                 val mockStreak = 7
 
                 _uiState.update {
@@ -214,7 +227,11 @@ class HomeViewModel @Inject constructor(
 
             try {
                 // TODO: Replace with actual use case
-                val mockHighlight = getMockCommunityHighlight()
+                // val highlight = getCommunityHighlightsUseCase()
+
+                // Temporary mock data for development
+                val mockHighlight = createMockCommunityHighlight()
+
                 _uiState.update {
                     it.copy(
                         communityHighlight = mockHighlight,
@@ -274,9 +291,9 @@ class HomeViewModel @Inject constructor(
         }
     }
 
-    // Mock data functions - TODO: Remove when real use cases are implemented
-    private fun getMockUser(): User {
-        return User(
+    // Temporary mock data functions - TODO: Remove when real use cases are implemented
+    private fun createMockUser(): com.dailychaos.project.domain.model.User {
+        return com.dailychaos.project.domain.model.User(
             id = "mock_user_1",
             anonymousUsername = "Kazuma2025",
             chaosEntriesCount = 15,
@@ -286,7 +303,7 @@ class HomeViewModel @Inject constructor(
         )
     }
 
-    private fun getMockTodayStats(): TodayStats {
+    private fun createMockTodayStats(): TodayStats {
         return TodayStats(
             entriesCount = 2,
             miniWinsCount = 5,
@@ -298,14 +315,11 @@ class HomeViewModel @Inject constructor(
         )
     }
 
-    private fun getMockRecentEntries(): List<ChaosEntry> {
-        // Return mock chaos entries
-        return listOf(
-            // TODO: Create mock entries or use existing sample data
-        )
+    private fun createMockRecentEntries(): List<com.dailychaos.project.domain.model.ChaosEntry> {
+        return emptyList() // Return empty for now, will be populated when data layer is implemented
     }
 
-    private fun getMockAchievements(): List<Achievement> {
+    private fun createMockAchievements(): List<Achievement> {
         return listOf(
             Achievement(
                 id = "streak_7",
@@ -339,7 +353,7 @@ class HomeViewModel @Inject constructor(
         )
     }
 
-    private fun getMockCommunityHighlight(): CommunityHighlight {
+    private fun createMockCommunityHighlight(): CommunityHighlight {
         return CommunityHighlight(
             id = "highlight_1",
             title = "Aqua Moment",


### PR DESCRIPTION
This commit refactors the `HomeScreen` and its associated `HomeViewModel` for a cleaner, more mobile-focused design and improved code structure.

**UI Changes (`HomeScreen.kt`, `MainNavigationScreen.kt`):**

- **Removed Floating Action Button (FAB):** The FAB for creating new entries and navigating to the community has been removed from `MainNavigationScreen` to simplify the main navigation.
- **Integrated Stats in Welcome Header:** The "Today's Quick Stats" section is now integrated directly into the `WelcomeHeader` in `HomeScreen` for a more compact and prominent display.
- **Simplified Placeholder Screens:** Placeholder screens in `MainNavigationScreen` (Journal, Community, Profile, etc.) now feature a more minimalistic design with an emoji and screen title. Spacing and button styles have been standardized.
- **Removed Quick Actions Section:** The dedicated "Quick Actions" section in `HomeScreen` has been removed as its functionality is accessible through the bottom navigation and potentially other UI elements.
- **Consolidated Recent Chaos Section:** `RecentChaosSectionWithData` is renamed to `RecentChaosSection`, and `CompactChaosCard` is replaced by `ChaosEntryCard`.
- **Consolidated Achievement Section:** `AchievementSectionWithData` is renamed to `AchievementSection`, and `AchievementChip` is renamed to `AchievementBadge`.
- **Consolidated Community Highlights Section:** `CommunityHighlightsSectionWithData` is renamed to `CommunityHighlightsSection`.
- **Improved Loading and Error States:** Updated loading indicators and error messages for better visual feedback.
- **Pull-to-Refresh Update:** Switched from `androidx.compose.material3.pulltorefresh` to `androidx.compose.material.pullrefresh` for the pull-to-refresh mechanism in `HomeScreen`.
- **Minor Styling Adjustments:** Various minor styling tweaks for consistency and clarity.

**ViewModel Changes (`HomeViewModel.kt`):**

- **Simplified Navigation Events:** Navigation-related events (e.g., `NavigateToEntry`, `NavigateToCreateChaos`) in `HomeUiEvent` now primarily serve as signals, with the actual navigation logic handled by the UI layer.
- **Renamed Mock Data Functions:** Mock data generation functions (e.g., `getMockUser` to `createMockUser`) have been renamed for clarity, emphasizing their temporary nature.
- **Updated Mock Data:** `createMockRecentEntries` now returns an empty list by default, deferring to the actual data layer implementation.

**IDE Configuration (`deploymentTargetSelector.xml`):**

- Removed an obsolete run configuration entry for `ChaosEntryCardPreview`.