### PR TITLE
Fix: Navigate to correct detail route in MainNavigationScreen

### DIFF
--- a/app/src/main/java/com/dailychaos/project/presentation/ui/component/MainNavigationScreen.kt
+++ b/app/src/main/java/com/dailychaos/project/presentation/ui/component/MainNavigationScreen.kt
@@ -75,7 +75,8 @@ fun MainNavigationScreen(
 
             composable("community") {
                 CommunityFeedScreen(
-                    onNavigateToPost = { id -> navController.navigate("community_post/$id") },
+                    // FIX: Navigate to the correct detail route
+                    onNavigateToPost = { id -> navController.navigate("chaos_detail/$id") },
                     onNavigateToTwins = { navController.navigate("chaos_twins") }
                 )
             }
@@ -108,7 +109,8 @@ fun MainNavigationScreen(
             composable("chaos_twins") {
                 ChaosTwinsScreen(
                     onNavigateBack = { navController.popBackStack() },
-                    onNavigateToPost = { id -> navController.navigate("community_post/$id") }
+                    // FIX: Navigate to the correct detail route
+                    onNavigateToPost = { id -> navController.navigate("chaos_detail/$id") }
                 )
             }
 


### PR DESCRIPTION
The `onNavigateToPost` callbacks in `CommunityFeedScreen` and `ChaosTwinsScreen` were navigating to "community_post/{id}".

This commit changes the navigation destination to "chaos_detail/{id}" to ensure users are directed to the correct detail screen.