### PR TITLE
feat(auth): Refactor ViewModels and Fix Auth Screen UX

### DIFF
--- a/app/src/main/java/com/dailychaos/project/presentation/ui/screen/auth/profile/ProfileViewModel.kt
+++ b/app/src/main/java/com/dailychaos/project/presentation/ui/screen/auth/profile/ProfileViewModel.kt
@@ -1,74 +1,50 @@
-// File: app/src/main/java/com/dailychaos/project/presentation/ui/screen/auth/profile/ProfileViewModel.kt
+/* app/src/main/java/com/dailychaos/project/presentation/ui/screen/auth/profile/ProfileViewModel.kt */
 package com.dailychaos.project.presentation.ui.screen.auth.profile
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.dailychaos.project.data.remote.firebase.FirebaseAuthService
+import com.dailychaos.project.domain.model.User
 import com.dailychaos.project.domain.model.UserProfile
-// Import UserPreferences
-import com.dailychaos.project.preferences.UserPreferences
+import com.dailychaos.project.domain.usecase.auth.AuthUseCases
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-// Import 'first()'
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class ProfileViewModel @Inject constructor(
-    private val firebaseAuthService: FirebaseAuthService,
-    // 1. Inject UserPreferences
-    private val userPreferences: UserPreferences
+    private val authUseCases: AuthUseCases
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(ProfileUiState())
     val uiState: StateFlow<ProfileUiState> = _uiState.asStateFlow()
 
     init {
-        // Cukup panggil loadUserProfile, pengecekan auth ada di dalamnya
         loadUserProfile()
     }
 
     fun loadUserProfile() {
         viewModelScope.launch {
             _uiState.value = _uiState.value.copy(isLoading = true, error = null)
-
             try {
-                // 2. Ambil UID dari UserPreferences sebagai sumber kebenaran
-                val userId = userPreferences.userId.first()
-
-                if (userId.isNullOrBlank()) {
-                    // Jika tidak ada UID di preferences, berarti user belum login dengan benar
-                    throw Exception("User ID tidak ditemukan. Silakan login kembali.")
-                }
-
-                // 3. Panggil service dengan UID yang sudah pasti benar
-                val result = firebaseAuthService.getUserProfile(userId)
-
-                if (result.isSuccess) {
-                    val profileData = result.getOrNull()
-                    if (profileData != null) {
-                        val userProfile = parseUserProfile(profileData)
-                        _uiState.value = _uiState.value.copy(
-                            userProfile = userProfile,
-                            isLoading = false,
-                            error = null
-                        )
-                    } else {
-                        _uiState.value = _uiState.value.copy(isLoading = false, error = "Data profil kosong.")
-                    }
+                val user = authUseCases.getCurrentUser()
+                if (user != null) {
+                    _uiState.value = _uiState.value.copy(
+                        userProfile = mapDomainUserToUiProfile(user),
+                        isLoading = false
+                    )
                 } else {
                     _uiState.value = _uiState.value.copy(
                         isLoading = false,
-                        error = result.exceptionOrNull()?.message ?: "Gagal memuat profil."
+                        error = "Could not load user profile. Please login again."
                     )
                 }
             } catch (e: Exception) {
                 _uiState.value = _uiState.value.copy(
                     isLoading = false,
-                    error = e.message ?: "Terjadi kesalahan."
+                    error = e.message ?: "An unexpected error occurred."
                 )
             }
         }
@@ -76,63 +52,24 @@ class ProfileViewModel @Inject constructor(
 
     fun logout() {
         viewModelScope.launch {
-            try {
-                firebaseAuthService.logout()
-                _uiState.value = ProfileUiState() // Reset state
-            } catch (e: Exception) {
-                _uiState.value = _uiState.value.copy(
-                    error = "Failed to logout: ${e.message}"
-                )
-            }
+            authUseCases.logout()
+            // The navigation to the login screen is handled by the UI
+            // after observing the auth state change.
         }
     }
 
-    /**
-     * Parse user profile data from Firebase with safe type casting
-     * Fix: Handle different data types that may come from Firebase
-     */
-    private fun parseUserProfile(data: Map<String, Any>): UserProfile {
+    private fun mapDomainUserToUiProfile(user: User): UserProfile {
         return UserProfile(
-            userId = data["userId"] as? String ?: "",
-            username = data["username"] as? String,
-            displayName = data["displayName"] as? String ?: "Adventurer",
-            email = data["email"] as? String,
-            chaosEntries = when (val entries = data["chaosEntries"]) {
-                is Long -> entries.toInt()
-                is Int -> entries
-                is Double -> entries.toInt()
-                is String -> entries.toIntOrNull() ?: 0
-                else -> 0
-            },
-            dayStreak = when (val streak = data["dayStreak"]) {
-                is Long -> streak.toInt()
-                is Int -> streak
-                is Double -> streak.toInt()
-                is String -> streak.toIntOrNull() ?: 0
-                else -> 0
-            },
-            supportGiven = when (val support = data["supportGiven"]) {
-                is Long -> support.toInt()
-                is Int -> support
-                is Double -> support.toInt()
-                is String -> support.toIntOrNull() ?: 0
-                else -> 0
-            },
-            joinDate = data["joinDate"] as? String ?: "",
-            authType = data["authType"] as? String ?: "username",
-            profilePicture = data["profilePicture"] as? String,
-            bio = data["bio"] as? String ?: "",
-            chaosLevel = when (val level = data["chaosLevel"]) {
-                is Long -> level.toInt()
-                is Int -> level
-                is Double -> level.toInt()
-                is String -> level.toIntOrNull() ?: 1
-                else -> 1
-            },
-            partyRole = data["partyRole"] as? String ?: "Newbie Adventurer",
-            isActive = data["isActive"] as? Boolean ?: true,
-            lastLoginDate = data["lastLoginDate"] as? String,
-            achievements = (data["achievements"] as? List<*>)?.mapNotNull { it as? String } ?: emptyList()
+            userId = user.id,
+            username = user.anonymousUsername,
+            displayName = user.anonymousUsername, // Assuming displayName is same as anonymousUsername for now
+            email = user.email,
+            chaosEntries = user.chaosEntriesCount,
+            dayStreak = user.streakDays,
+            supportGiven = user.supportGivenCount,
+            joinDate = user.joinedAt.toString(), // Simplified conversion
+            authType = if (user.isAnonymous) "username" else "email"
+            // Other fields can be mapped here if the domain model is expanded
         )
     }
 }

--- a/app/src/main/java/com/dailychaos/project/presentation/ui/screen/auth/register/RegisterScreen.kt
+++ b/app/src/main/java/com/dailychaos/project/presentation/ui/screen/auth/register/RegisterScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.focus.FocusManager
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
@@ -35,25 +36,26 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.dailychaos.project.presentation.ui.theme.ChaosColors
 import com.dailychaos.project.presentation.ui.component.PasswordStrengthIndicator
+import com.dailychaos.project.presentation.ui.theme.ChaosColors
 import com.dailychaos.project.util.PasswordStrength
+
+// --- FIX: Import yang hilang ditambahkan di sini ---
+import androidx.compose.material3.SuggestionChip
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun RegisterScreen(
     onNavigateToLogin: () -> Unit,
-    onRegisterSuccess: () -> Unit, // FIX: Callback akan redirect ke login screen
+    onRegisterSuccess: () -> Unit,
     modifier: Modifier = Modifier,
     viewModel: RegisterViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val focusManager = LocalFocusManager.current
 
-    // Observe register success event - FIX: Navigation akan ke login
     LaunchedEffect(Unit) {
         viewModel.registerSuccessEvent.collect {
-            // Ketika register berhasil, arahkan ke login screen
             onRegisterSuccess()
         }
     }
@@ -70,20 +72,15 @@ fun RegisterScreen(
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.Center
         ) {
-            // Header - UPDATED dengan pesan yang lebih jelas
             RegisterHeader()
-
             Spacer(modifier = Modifier.height(32.dp))
 
-            // Register Mode Toggle
             RegisterModeToggle(
                 selectedMode = uiState.registerMode,
                 onModeSelected = { viewModel.onEvent(RegisterEvent.SwitchRegisterMode(it)) }
             )
-
             Spacer(modifier = Modifier.height(24.dp))
 
-            // Register Form
             when (uiState.registerMode) {
                 RegisterMode.USERNAME -> {
                     UsernameRegisterForm(
@@ -109,9 +106,9 @@ fun RegisterScreen(
                         isPasswordVisible = uiState.isPasswordVisible,
                         isConfirmPasswordVisible = uiState.isConfirmPasswordVisible,
                         isLoading = uiState.isLoading,
-                        emailError = uiState.emailError, // ADDED error handling
-                        passwordError = uiState.passwordError, // ADDED error handling
-                        confirmPasswordError = uiState.confirmPasswordError, // ADDED error handling
+                        emailError = uiState.emailError,
+                        passwordError = uiState.passwordError,
+                        confirmPasswordError = uiState.confirmPasswordError,
                         onEmailChanged = { viewModel.onEvent(RegisterEvent.EmailChanged(it)) },
                         onPasswordChanged = { viewModel.onEvent(RegisterEvent.PasswordChanged(it)) },
                         onConfirmPasswordChanged = { viewModel.onEvent(RegisterEvent.ConfirmPasswordChanged(it)) },
@@ -126,7 +123,6 @@ fun RegisterScreen(
 
             Spacer(modifier = Modifier.height(16.dp))
 
-            // Error Message
             AnimatedVisibility(
                 visible = uiState.error != null,
                 enter = expandVertically() + fadeIn(),
@@ -162,8 +158,6 @@ fun RegisterScreen(
             }
 
             Spacer(modifier = Modifier.height(24.dp))
-
-            // Login Redirect - UPDATED dengan pesan yang lebih jelas
             LoginRedirectSection(onNavigateToLogin = onNavigateToLogin)
         }
     }
@@ -171,9 +165,7 @@ fun RegisterScreen(
 
 @Composable
 private fun RegisterHeader() {
-    Column(
-        horizontalAlignment = Alignment.CenterHorizontally
-    ) {
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
         Text(
             text = "Join the Party! 🎉",
             style = MaterialTheme.typography.headlineLarge.copy(
@@ -188,7 +180,6 @@ private fun RegisterHeader() {
             textAlign = TextAlign.Center,
             color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f)
         )
-        // ADDED: Info tentang flow registrasi
         Spacer(modifier = Modifier.height(4.dp))
         Text(
             text = "Setelah registrasi, kamu akan diarahkan ke halaman login untuk masuk",
@@ -211,11 +202,7 @@ private fun RegisterModeToggle(
         ),
         shape = RoundedCornerShape(16.dp)
     ) {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(4.dp)
-        ) {
+        Row(modifier = Modifier.fillMaxWidth().padding(4.dp)) {
             RegisterModeButton(
                 text = "Username",
                 icon = Icons.Default.Person,
@@ -237,7 +224,7 @@ private fun RegisterModeToggle(
 @Composable
 private fun RegisterModeButton(
     text: String,
-    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    icon: ImageVector,
     isSelected: Boolean,
     onClick: () -> Unit,
     modifier: Modifier = Modifier
@@ -283,45 +270,27 @@ private fun UsernameRegisterForm(
     onRegister: () -> Unit,
     focusManager: FocusManager
 ) {
-    Column(
-        modifier = Modifier.fillMaxWidth()
-    ) {
-        // Display Name Field
+    Column(modifier = Modifier.fillMaxWidth()) {
         OutlinedTextField(
             value = displayName,
             onValueChange = onDisplayNameChanged,
             label = { Text("Display Name (Optional)") },
             placeholder = { Text("Contoh: Kazuma si Petualang") },
-            leadingIcon = {
-                Icon(
-                    imageVector = Icons.Default.Badge,
-                    contentDescription = null
-                )
-            },
-            keyboardOptions = KeyboardOptions(
-                imeAction = ImeAction.Next
-            ),
-            keyboardActions = KeyboardActions(
-                onNext = { focusManager.moveFocus(FocusDirection.Down) }
-            ),
+            leadingIcon = { Icon(imageVector = Icons.Default.Badge, contentDescription = null) },
+            singleLine = true,
+            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),
+            keyboardActions = KeyboardActions(onNext = { focusManager.moveFocus(FocusDirection.Down) }),
             modifier = Modifier.fillMaxWidth(),
             shape = RoundedCornerShape(12.dp)
         )
-
         Spacer(modifier = Modifier.height(16.dp))
 
-        // Username Field
         OutlinedTextField(
             value = username,
             onValueChange = onUsernameChanged,
             label = { Text("Username") },
             placeholder = { Text("Contoh: kazuma_adventurer") },
-            leadingIcon = {
-                Icon(
-                    imageVector = Icons.Default.Person,
-                    contentDescription = null
-                )
-            },
+            leadingIcon = { Icon(imageVector = Icons.Default.Person, contentDescription = null) },
             trailingIcon = {
                 if (username.isNotEmpty()) {
                     Icon(
@@ -332,20 +301,19 @@ private fun UsernameRegisterForm(
                 }
             },
             isError = usernameError != null,
-            supportingText = if (usernameError != null) {
-                { Text(usernameError) }
-            } else null,
-            keyboardOptions = KeyboardOptions(
-                imeAction = ImeAction.Done
-            ),
+            supportingText = if (usernameError != null) { { Text(usernameError) } } else null,
+            singleLine = true,
+            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
             keyboardActions = KeyboardActions(
-                onDone = { onRegister() }
+                onDone = {
+                    focusManager.clearFocus()
+                    onRegister()
+                }
             ),
             modifier = Modifier.fillMaxWidth(),
             shape = RoundedCornerShape(12.dp)
         )
 
-        // Username Suggestions
         AnimatedVisibility(
             visible = suggestions.isNotEmpty(),
             enter = expandVertically() + fadeIn(),
@@ -359,9 +327,7 @@ private fun UsernameRegisterForm(
                     color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f)
                 )
                 Spacer(modifier = Modifier.height(4.dp))
-                LazyRow(
-                    horizontalArrangement = Arrangement.spacedBy(8.dp)
-                ) {
+                LazyRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                     items(suggestions) { suggestion ->
                         SuggestionChip(
                             onClick = { onSuggestionClicked(suggestion) },
@@ -371,19 +337,13 @@ private fun UsernameRegisterForm(
                 }
             }
         }
-
         Spacer(modifier = Modifier.height(24.dp))
 
-        // Register Button
         Button(
             onClick = onRegister,
             enabled = isUsernameValid && !isLoading,
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(56.dp),
-            colors = ButtonDefaults.buttonColors(
-                containerColor = ChaosColors.primary
-            ),
+            modifier = Modifier.fillMaxWidth().height(56.dp),
+            colors = ButtonDefaults.buttonColors(containerColor = ChaosColors.primary),
             shape = RoundedCornerShape(12.dp)
         ) {
             if (isLoading) {
@@ -401,9 +361,7 @@ private fun UsernameRegisterForm(
                 Spacer(modifier = Modifier.width(8.dp))
                 Text(
                     text = "Join the Party!",
-                    style = MaterialTheme.typography.bodyLarge.copy(
-                        fontWeight = FontWeight.SemiBold
-                    )
+                    style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.SemiBold)
                 )
             }
         }
@@ -419,9 +377,9 @@ private fun EmailRegisterForm(
     isPasswordVisible: Boolean,
     isConfirmPasswordVisible: Boolean,
     isLoading: Boolean,
-    emailError: String?, // ADDED
-    passwordError: String?, // ADDED
-    confirmPasswordError: String?, // ADDED
+    emailError: String?,
+    passwordError: String?,
+    confirmPasswordError: String?,
     onEmailChanged: (String) -> Unit,
     onPasswordChanged: (String) -> Unit,
     onConfirmPasswordChanged: (String) -> Unit,
@@ -431,75 +389,44 @@ private fun EmailRegisterForm(
     onRegister: () -> Unit,
     focusManager: FocusManager
 ) {
-    Column(
-        modifier = Modifier.fillMaxWidth()
-    ) {
-        // Display Name Field
+    Column(modifier = Modifier.fillMaxWidth()) {
         OutlinedTextField(
             value = displayName,
             onValueChange = onDisplayNameChanged,
             label = { Text("Display Name (Optional)") },
             placeholder = { Text("Contoh: Kazuma si Petualang") },
-            leadingIcon = {
-                Icon(
-                    imageVector = Icons.Default.Badge,
-                    contentDescription = null
-                )
-            },
-            keyboardOptions = KeyboardOptions(
-                imeAction = ImeAction.Next
-            ),
-            keyboardActions = KeyboardActions(
-                onNext = { focusManager.moveFocus(FocusDirection.Down) }
-            ),
+            leadingIcon = { Icon(imageVector = Icons.Default.Badge, contentDescription = null) },
+            singleLine = true,
+            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),
+            keyboardActions = KeyboardActions(onNext = { focusManager.moveFocus(FocusDirection.Down) }),
             modifier = Modifier.fillMaxWidth(),
             shape = RoundedCornerShape(12.dp)
         )
-
         Spacer(modifier = Modifier.height(16.dp))
 
-        // Email Field
         OutlinedTextField(
             value = email,
             onValueChange = onEmailChanged,
             label = { Text("Email") },
             placeholder = { Text("contoh@email.com") },
-            leadingIcon = {
-                Icon(
-                    imageVector = Icons.Default.Email,
-                    contentDescription = null
-                )
-            },
-            isError = emailError != null, // ADDED
-            supportingText = if (emailError != null) { // ADDED
-                { Text(emailError) }
-            } else null,
-            keyboardOptions = KeyboardOptions(
-                keyboardType = KeyboardType.Email,
-                imeAction = ImeAction.Next
-            ),
-            keyboardActions = KeyboardActions(
-                onNext = { focusManager.moveFocus(FocusDirection.Down) }
-            ),
+            leadingIcon = { Icon(imageVector = Icons.Default.Email, contentDescription = null) },
+            isError = emailError != null,
+            supportingText = if (emailError != null) { { Text(emailError) } } else null,
+            singleLine = true,
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Email, imeAction = ImeAction.Next),
+            keyboardActions = KeyboardActions(onNext = { focusManager.moveFocus(FocusDirection.Down) }),
             modifier = Modifier.fillMaxWidth(),
             shape = RoundedCornerShape(12.dp)
         )
-
         Spacer(modifier = Modifier.height(16.dp))
 
-        // Password Field
         OutlinedTextField(
             value = password,
             onValueChange = onPasswordChanged,
             label = { Text("Password") },
             placeholder = { Text("Minimal 6 karakter") },
             visualTransformation = if (isPasswordVisible) VisualTransformation.None else PasswordVisualTransformation(),
-            leadingIcon = {
-                Icon(
-                    imageVector = Icons.Default.Lock,
-                    contentDescription = null
-                )
-            },
+            leadingIcon = { Icon(imageVector = Icons.Default.Lock, contentDescription = null) },
             trailingIcon = {
                 IconButton(onClick = onTogglePasswordVisibility) {
                     Icon(
@@ -508,46 +435,31 @@ private fun EmailRegisterForm(
                     )
                 }
             },
-            isError = passwordError != null, // ADDED
-            supportingText = if (passwordError != null) { // ADDED
-                { Text(passwordError) }
-            } else null,
-            keyboardOptions = KeyboardOptions(
-                keyboardType = KeyboardType.Password,
-                imeAction = ImeAction.Next
-            ),
-            keyboardActions = KeyboardActions(
-                onNext = { focusManager.moveFocus(FocusDirection.Down) }
-            ),
+            isError = passwordError != null,
+            supportingText = if (passwordError != null) { { Text(passwordError) } } else null,
+            singleLine = true,
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password, imeAction = ImeAction.Next),
+            keyboardActions = KeyboardActions(onNext = { focusManager.moveFocus(FocusDirection.Down) }),
             modifier = Modifier.fillMaxWidth(),
             shape = RoundedCornerShape(12.dp)
         )
-
         Spacer(modifier = Modifier.height(8.dp))
 
-        // Password Strength Indicator
         if (password.isNotEmpty()) {
             PasswordStrengthIndicator(
                 password = password,
                 strength = calculatePasswordStrength(password)
             )
         }
-
         Spacer(modifier = Modifier.height(16.dp))
 
-        // Confirm Password Field
         OutlinedTextField(
             value = confirmPassword,
             onValueChange = onConfirmPasswordChanged,
             label = { Text("Confirm Password") },
             placeholder = { Text("Ketik ulang password") },
             visualTransformation = if (isConfirmPasswordVisible) VisualTransformation.None else PasswordVisualTransformation(),
-            leadingIcon = {
-                Icon(
-                    imageVector = Icons.Default.Lock,
-                    contentDescription = null
-                )
-            },
+            leadingIcon = { Icon(imageVector = Icons.Default.Lock, contentDescription = null) },
             trailingIcon = {
                 IconButton(onClick = onToggleConfirmPasswordVisibility) {
                     Icon(
@@ -556,33 +468,26 @@ private fun EmailRegisterForm(
                     )
                 }
             },
-            isError = confirmPasswordError != null, // ADDED
-            supportingText = if (confirmPasswordError != null) { // ADDED
-                { Text(confirmPasswordError) }
-            } else null,
-            keyboardOptions = KeyboardOptions(
-                keyboardType = KeyboardType.Password,
-                imeAction = ImeAction.Done
-            ),
+            isError = confirmPasswordError != null,
+            supportingText = if (confirmPasswordError != null) { { Text(confirmPasswordError) } } else null,
+            singleLine = true,
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password, imeAction = ImeAction.Done),
             keyboardActions = KeyboardActions(
-                onDone = { onRegister() }
+                onDone = {
+                    focusManager.clearFocus()
+                    onRegister()
+                }
             ),
             modifier = Modifier.fillMaxWidth(),
             shape = RoundedCornerShape(12.dp)
         )
-
         Spacer(modifier = Modifier.height(24.dp))
 
-        // Register Button
         Button(
             onClick = onRegister,
             enabled = email.isNotEmpty() && password.isNotEmpty() && confirmPassword.isNotEmpty() && !isLoading,
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(56.dp),
-            colors = ButtonDefaults.buttonColors(
-                containerColor = ChaosColors.primary
-            ),
+            modifier = Modifier.fillMaxWidth().height(56.dp),
+            colors = ButtonDefaults.buttonColors(containerColor = ChaosColors.primary),
             shape = RoundedCornerShape(12.dp)
         ) {
             if (isLoading) {
@@ -600,9 +505,7 @@ private fun EmailRegisterForm(
                 Spacer(modifier = Modifier.width(8.dp))
                 Text(
                     text = "Create Account",
-                    style = MaterialTheme.typography.bodyLarge.copy(
-                        fontWeight = FontWeight.SemiBold
-                    )
+                    style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.SemiBold)
                 )
             }
         }
@@ -610,22 +513,14 @@ private fun EmailRegisterForm(
 }
 
 @Composable
-private fun LoginRedirectSection(
-    onNavigateToLogin: () -> Unit
-) {
-    Column(
-        horizontalAlignment = Alignment.CenterHorizontally
-    ) {
+private fun LoginRedirectSection(onNavigateToLogin: () -> Unit) {
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
         HorizontalDivider(
             modifier = Modifier.fillMaxWidth(0.8f),
             color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.2f)
         )
-
         Spacer(modifier = Modifier.height(16.dp))
-
-        Row(
-            verticalAlignment = Alignment.CenterVertically
-        ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
             Text(
                 text = "Sudah punya akun? ",
                 style = MaterialTheme.typography.bodyMedium,
@@ -643,21 +538,14 @@ private fun LoginRedirectSection(
     }
 }
 
-/**
- * Calculate password strength for UI display
- */
 private fun calculatePasswordStrength(password: String): PasswordStrength {
     var score = 0
-
-    // Length bonus
     if (password.length >= 8) score += 1
     if (password.length >= 12) score += 1
-
-    // Character variety
     if (password.any { it.isLowerCase() }) score += 1
     if (password.any { it.isUpperCase() }) score += 1
     if (password.any { it.isDigit() }) score += 1
-    if (password.any { "!@#$%^&*()_+-=[]{}|;:,.<>?".contains(it) }) score += 1
+    if (password.any { "!@#\$%^&*()_+-=[]{}|;:,.<>?".contains(it) }) score += 1
 
     return when (score) {
         in 0..2 -> PasswordStrength.WEAK

--- a/app/src/main/java/com/dailychaos/project/presentation/ui/screen/auth/register/RegisterViewModel.kt
+++ b/app/src/main/java/com/dailychaos/project/presentation/ui/screen/auth/register/RegisterViewModel.kt
@@ -1,11 +1,10 @@
-// File: app/src/main/java/com/dailychaos/project/presentation/ui/screen/auth/register/RegisterViewModel.kt
+/* app/src/main/java/com/dailychaos/project/presentation/ui/screen/auth/register/RegisterViewModel.kt */
 package com.dailychaos.project.presentation.ui.screen.auth.register
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.dailychaos.project.data.remote.firebase.FirebaseAuthService
+import com.dailychaos.project.domain.usecase.auth.AuthUseCases
 import com.dailychaos.project.preferences.UserPreferences
-import com.dailychaos.project.util.ValidationUtil
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -15,9 +14,8 @@ import javax.inject.Inject
 
 @HiltViewModel
 class RegisterViewModel @Inject constructor(
-    private val firebaseAuthService: FirebaseAuthService,
-    private val userPreferences: UserPreferences,
-    private val validationUtil: ValidationUtil
+    private val authUseCases: AuthUseCases,
+    private val userPreferences: UserPreferences
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(RegisterUiState())
@@ -30,29 +28,19 @@ class RegisterViewModel @Inject constructor(
 
     fun onEvent(event: RegisterEvent) {
         when (event) {
-            is RegisterEvent.DisplayNameChanged -> {
-                _uiState.update { it.copy(displayName = event.displayName) }
-            }
-            is RegisterEvent.SwitchRegisterMode -> {
-                _uiState.update {
-                    it.copy(
-                        registerMode = event.mode,
-                        error = null,
-                        usernameError = null,
-                        emailError = null,
-                        passwordError = null,
-                        confirmPasswordError = null
-                    )
-                }
+            is RegisterEvent.DisplayNameChanged -> _uiState.update { it.copy(displayName = event.displayName) }
+            is RegisterEvent.SwitchRegisterMode -> _uiState.update {
+                it.copy(
+                    registerMode = event.mode,
+                    error = null,
+                    usernameError = null,
+                    emailError = null,
+                    passwordError = null,
+                    confirmPasswordError = null
+                )
             }
             is RegisterEvent.UsernameChanged -> {
-                _uiState.update {
-                    it.copy(
-                        username = event.username,
-                        usernameError = null,
-                        error = null
-                    )
-                }
+                _uiState.update { it.copy(username = event.username, usernameError = null, error = null) }
                 validateUsernameWithDelay(event.username)
             }
             is RegisterEvent.SuggestionClicked -> {
@@ -65,44 +53,14 @@ class RegisterViewModel @Inject constructor(
                     )
                 }
             }
-            is RegisterEvent.EmailChanged -> {
-                _uiState.update {
-                    it.copy(
-                        email = event.email,
-                        emailError = null,
-                        error = null
-                    )
-                }
-            }
-            is RegisterEvent.PasswordChanged -> {
-                _uiState.update {
-                    it.copy(
-                        password = event.password,
-                        passwordError = null,
-                        error = null
-                    )
-                }
-            }
-            is RegisterEvent.ConfirmPasswordChanged -> {
-                _uiState.update {
-                    it.copy(
-                        confirmPassword = event.confirmPassword,
-                        confirmPasswordError = null,
-                        error = null
-                    )
-                }
-            }
-            RegisterEvent.TogglePasswordVisibility -> {
-                _uiState.update { it.copy(isPasswordVisible = !it.isPasswordVisible) }
-            }
-            RegisterEvent.ToggleConfirmPasswordVisibility -> {
-                _uiState.update { it.copy(isConfirmPasswordVisible = !it.isConfirmPasswordVisible) }
-            }
-            RegisterEvent.RegisterWithUsername -> registerWithUsername()
-            RegisterEvent.RegisterWithEmail -> registerWithEmail()
-            RegisterEvent.ClearError -> {
-                _uiState.update { it.copy(error = null) }
-            }
+            is RegisterEvent.EmailChanged -> _uiState.update { it.copy(email = event.email, emailError = null, error = null) }
+            is RegisterEvent.PasswordChanged -> _uiState.update { it.copy(password = event.password, passwordError = null, error = null) }
+            is RegisterEvent.ConfirmPasswordChanged -> _uiState.update { it.copy(confirmPassword = event.confirmPassword, confirmPasswordError = null, error = null) }
+            is RegisterEvent.TogglePasswordVisibility -> _uiState.update { it.copy(isPasswordVisible = !it.isPasswordVisible) }
+            is RegisterEvent.ToggleConfirmPasswordVisibility -> _uiState.update { it.copy(isConfirmPasswordVisible = !it.isConfirmPasswordVisible) }
+            is RegisterEvent.RegisterWithUsername -> registerWithUsername()
+            is RegisterEvent.RegisterWithEmail -> registerWithEmail()
+            is RegisterEvent.ClearError -> _uiState.update { it.copy(error = null) }
         }
     }
 
@@ -110,192 +68,61 @@ class RegisterViewModel @Inject constructor(
         usernameValidationJob?.cancel()
         usernameValidationJob = viewModelScope.launch {
             delay(500) // Debounce validation
-            validateUsername(username)
-        }
-    }
-
-    private fun validateUsername(username: String) {
-        if (username.isBlank()) {
+            val validation = authUseCases.validateUsername(username)
             _uiState.update {
                 it.copy(
-                    isUsernameValid = false,
-                    usernameError = null,
-                    suggestions = emptyList()
+                    isUsernameValid = validation.isValid,
+                    usernameError = if (validation.isValid) null else validation.message,
+                    suggestions = validation.suggestions
                 )
             }
-            return
         }
-
-        viewModelScope.launch {
-            try {
-                val validationResult = validationUtil.validateUsername(username)
-
-                when {
-                    validationResult.isValid -> {
-                        // Check availability
-                        val isAvailable = firebaseAuthService.checkUsernameAvailability(username)
-                        if (isAvailable) {
-                            _uiState.update {
-                                it.copy(
-                                    isUsernameValid = true,
-                                    usernameError = null,
-                                    suggestions = emptyList()
-                                )
-                            }
-                        } else {
-                            val suggestions = generateUsernameSuggestions(username)
-                            _uiState.update {
-                                it.copy(
-                                    isUsernameValid = false,
-                                    usernameError = "Username sudah digunakan!",
-                                    suggestions = suggestions
-                                )
-                            }
-                        }
-                    }
-                    else -> {
-                        _uiState.update {
-                            it.copy(
-                                isUsernameValid = false,
-                                usernameError = validationResult.message,
-                                suggestions = emptyList()
-                            )
-                        }
-                    }
-                }
-            } catch (e: Exception) {
-                _uiState.update {
-                    it.copy(
-                        isUsernameValid = false,
-                        usernameError = "Error validating username: ${e.message}",
-                        suggestions = emptyList()
-                    )
-                }
-            }
-        }
-    }
-
-    private fun generateUsernameSuggestions(baseUsername: String): List<String> {
-        val suggestions = mutableListOf<String>()
-        val randomNumbers = (100..999).shuffled().take(3)
-
-        randomNumbers.forEach { number ->
-            suggestions.add("${baseUsername}$number")
-        }
-
-        // Add some creative variations
-        val variations = listOf(
-            "${baseUsername}_chaos",
-            "${baseUsername}hero",
-            "chaos_$baseUsername"
-        )
-
-        suggestions.addAll(variations.take(2))
-        return suggestions.take(5)
     }
 
     private fun registerWithUsername() {
-        val state = _uiState.value
-
-        if (state.username.isBlank()) {
-            _uiState.update { it.copy(usernameError = "Username tidak boleh kosong!") }
-            return
-        }
-
-        if (!state.isUsernameValid) {
-            _uiState.update { it.copy(usernameError = "Username tidak valid atau sudah digunakan!") }
-            return
-        }
-
         viewModelScope.launch {
+            if (!_uiState.value.isUsernameValid) {
+                _uiState.update { it.copy(usernameError = "Please enter a valid and available username.") }
+                return@launch
+            }
             _uiState.update { it.copy(isLoading = true, error = null) }
 
-            try {
-                val result = firebaseAuthService.registerWithUsername(
-                    username = state.username,
-                    displayName = state.displayName.ifBlank { state.username }
-                )
+            val result = authUseCases.registerWithUsername(
+                username = _uiState.value.username,
+                displayName = _uiState.value.displayName.ifBlank { _uiState.value.username }
+            )
 
-                if (result.isSuccess) {
-                    // Mark first launch as completed after successful registration
-                    userPreferences.setFirstLaunchCompleted()
-                    _registerSuccessEvent.emit(Unit)
-                } else {
-                    val error = result.exceptionOrNull()?.message ?: "Registrasi gagal"
-                    _uiState.update {
-                        it.copy(
-                            isLoading = false,
-                            error = error
-                        )
-                    }
-                }
-            } catch (e: Exception) {
-                _uiState.update {
-                    it.copy(
-                        isLoading = false,
-                        error = e.message ?: "Terjadi kesalahan saat registrasi"
-                    )
-                }
+            result.onSuccess {
+                userPreferences.setFirstLaunchCompleted()
+                _uiState.update { it.copy(isLoading = false) }
+                _registerSuccessEvent.emit(Unit)
+            }.onFailure { error ->
+                _uiState.update { it.copy(isLoading = false, error = error.message) }
             }
         }
     }
 
     private fun registerWithEmail() {
         val state = _uiState.value
-
-        // Validate email
-        if (state.email.isBlank()) {
-            _uiState.update { it.copy(emailError = "Email tidak boleh kosong!") }
-            return
-        }
-
-        if (!validationUtil.isValidEmail(state.email)) {
-            _uiState.update { it.copy(emailError = "Format email tidak valid!") }
-            return
-        }
-
-        // Validate password
-        if (state.password.length < 6) {
-            _uiState.update { it.copy(passwordError = "Password minimal 6 karakter!") }
-            return
-        }
-
-        // Validate confirm password
-        if (state.confirmPassword != state.password) {
-            _uiState.update { it.copy(confirmPasswordError = "Password tidak sama!") }
+        if (state.password != state.confirmPassword) {
+            _uiState.update { it.copy(confirmPasswordError = "Passwords do not match.") }
             return
         }
 
         viewModelScope.launch {
             _uiState.update { it.copy(isLoading = true, error = null) }
+            val result = authUseCases.registerWithEmail(
+                email = state.email,
+                password = state.password,
+                displayName = state.displayName.ifBlank { "Chaos Adventurer" }
+            )
 
-            try {
-                val result = firebaseAuthService.registerWithEmail(
-                    email = state.email,
-                    password = state.password,
-                    displayName = state.displayName.ifBlank { "Chaos Member" }
-                )
-
-                if (result.isSuccess) {
-                    // Mark first launch as completed after successful registration
-                    userPreferences.setFirstLaunchCompleted()
-                    _registerSuccessEvent.emit(Unit)
-                } else {
-                    val error = result.exceptionOrNull()?.message ?: "Registrasi gagal"
-                    _uiState.update {
-                        it.copy(
-                            isLoading = false,
-                            error = error
-                        )
-                    }
-                }
-            } catch (e: Exception) {
-                _uiState.update {
-                    it.copy(
-                        isLoading = false,
-                        error = e.message ?: "Terjadi kesalahan saat registrasi"
-                    )
-                }
+            result.onSuccess {
+                userPreferences.setFirstLaunchCompleted()
+                _uiState.update { it.copy(isLoading = false) }
+                _registerSuccessEvent.emit(Unit)
+            }.onFailure { error ->
+                _uiState.update { it.copy(isLoading = false, error = error.message) }
             }
         }
     }

--- a/app/src/main/java/com/dailychaos/project/presentation/ui/screen/splash/SplashViewModel.kt
+++ b/app/src/main/java/com/dailychaos/project/presentation/ui/screen/splash/SplashViewModel.kt
@@ -1,7 +1,9 @@
+/* app/src/main/java/com/dailychaos/project/presentation/ui/screen/splash/SplashViewModel.kt */
 package com.dailychaos.project.presentation.ui.screen.splash
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.dailychaos.project.domain.usecase.auth.AuthUseCases
 import com.dailychaos.project.preferences.UserPreferences
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.delay
@@ -13,8 +15,8 @@ import javax.inject.Inject
 
 @HiltViewModel
 class SplashViewModel @Inject constructor(
-    private val userPreferences: UserPreferences
-    // private val authRepository: AuthRepository
+    private val userPreferences: UserPreferences,
+    private val authUseCases: AuthUseCases
 ) : ViewModel() {
 
     private val _navigationEvent = MutableSharedFlow<SplashDestination>()
@@ -26,12 +28,10 @@ class SplashViewModel @Inject constructor(
 
     private fun decideNextScreen() {
         viewModelScope.launch {
-            // Simulate a network/auth check
-            delay(2000)
+            // Simulate a minimum splash time for better user experience
+            delay(2500)
 
-            // In a real app, you would check the actual login state
-            // val isLoggedIn = authRepository.getCurrentUser() != null
-            val isLoggedIn = true // Placeholder for dev
+            val isLoggedIn = authUseCases.isAuthenticated()
             val onboardingCompleted = userPreferences.onboardingCompleted.first()
 
             val destination = when {


### PR DESCRIPTION
This commit introduces a major refactor to the authentication-related ViewModels and resolves several UI/UX issues in the login and register screens.

Refactor:
- Updated LoginViewModel, RegisterViewModel, ProfileViewModel, MainViewModel, and SplashViewModel to use the new `AuthUseCases`. This decouples the presentation layer from direct data source dependencies, improving testability and adhering to Clean Architecture principles.
- Corrected the login logic in `LoginViewModel` to use the appropriate `loginWithUsername` use case.

Fix:
- Resolved an issue in LoginScreen and RegisterScreen where pressing the "Enter" key created a newline instead of triggering the appropriate IME action (Next/Done).
- Implemented proper keyboard actions and focus management for a smoother user flow in both login and register forms.
- Corrected compiler errors in RegisterScreen by adding missing imports for `ChaosColors` and `SuggestionChip`.