### PR TITLE
Feat: Update user profile on support actions

### DIFF
--- a/app/src/main/java/com/dailychaos/project/data/remote/firebase/SupportCountService.kt
+++ b/app/src/main/java/com/dailychaos/project/data/remote/firebase/SupportCountService.kt
@@ -1,0 +1,4 @@
+package com.dailychaos.project.data.remote.firebase
+
+class SupportCountService {
+}


### PR DESCRIPTION
This commit modifies the `CommunityRepositoryImpl.kt` to update the user's profile when they give or remove support for a post.

Specifically, the following changes were made:
- When a user gives support:
    - `supportGiven`, `totalSupportsGiven`, and `totalSupportGiven` fields in the user's profile are incremented.
    - `lastActiveAt` field is updated with the current timestamp.
- When a user removes support:
    - `supportGiven`, `totalSupportsGiven`, and `totalSupportGiven` fields in the user's profile are decremented.
    - `lastActiveAt` field is updated with the current timestamp.
- Added more descriptive logging for support actions.
- Limited the query to 1 document when checking for existing support to improve efficiency.
- Improved error handling and logging when no support reaction is found to remove.

Additionally, a new empty class `SupportCountService.kt` was added.