### PR TITLE
Refactor: Enhance support comment interaction with report functionality

### DIFF
--- a/app/src/main/java/com/dailychaos/project/data/repository/CommunityRepositoryImpl.kt
+++ b/app/src/main/java/com/dailychaos/project/data/repository/CommunityRepositoryImpl.kt
@@ -263,6 +263,34 @@ class CommunityRepositoryImpl @Inject constructor(
         }
     }
 
+    override suspend fun getUserLikedComments(commentIds: List<String>, userId: String): List<String> {
+        return try {
+            Timber.d("🔍 Getting liked comments for user: $userId, comments: $commentIds")
+
+            if (commentIds.isEmpty()) {
+                return emptyList()
+            }
+
+            // Query collection comment_likes untuk mendapatkan like status
+            val likedComments = firestore.collection("comment_likes")
+                .whereEqualTo("userId", userId)
+                .whereIn("commentId", commentIds)
+                .get()
+                .await()
+
+            val likedCommentIds = likedComments.documents.mapNotNull { doc ->
+                doc.getString("commentId")
+            }
+
+            Timber.d("✅ Found ${likedCommentIds.size} liked comments: $likedCommentIds")
+            likedCommentIds
+
+        } catch (e: Exception) {
+            Timber.e(e, "❌ Error getting user liked comments")
+            emptyList()
+        }
+    }
+
     override suspend fun removeSupport(postId: String, userId: String): Result<Unit> {
         return try {
             Timber.d("💔 ==================== REMOVING SUPPORT ====================")

--- a/app/src/main/java/com/dailychaos/project/domain/repository/CommunityRepository.kt
+++ b/app/src/main/java/com/dailychaos/project/domain/repository/CommunityRepository.kt
@@ -163,4 +163,8 @@ interface CommunityRepositoryExtended : CommunityRepository {
      * Get comment statistics for a post
      */
     suspend fun getCommentStats(postId: String): Result<Map<SupportType, Int>>
+
+    suspend fun getUserLikedComments(commentIds: List<String>, userId: String): List<String>
+
+
 }

--- a/app/src/main/java/com/dailychaos/project/presentation/ui/screen/community/support/SupportUiState.kt
+++ b/app/src/main/java/com/dailychaos/project/presentation/ui/screen/community/support/SupportUiState.kt
@@ -1,4 +1,5 @@
-// File: app/src/main/java/com/dailychaos/project/presentation/ui/screen/community/support/SupportUiState.kt
+
+// File: SupportUiState.kt - UPDATE
 package com.dailychaos.project.presentation.ui.screen.community.support
 
 import com.dailychaos.project.domain.model.SupportComment
@@ -28,7 +29,13 @@ data class SupportUiState(
 
     // UI state
     val showCommentDialog: Boolean = false,
-    val expandedCommentId: String? = null
+    val expandedCommentId: String? = null,
+
+    // ✅ NEW: Report dialog state
+    val showReportDialog: Boolean = false,
+    val selectedCommentToReport: String? = null,
+    val reportReason: String = "",
+    val showCommentMenu: String? = null // ID comment yang menampilkan menu
 )
 
 /**
@@ -57,4 +64,12 @@ sealed class SupportEvent {
 
     // Reply system (for future)
     data class ReplyToComment(val parentCommentId: String) : SupportEvent()
+
+    // ✅ NEW: Menu and report events
+    data class ShowCommentMenu(val commentId: String) : SupportEvent()
+    object HideCommentMenu : SupportEvent()
+    data class ShowReportDialog(val commentId: String) : SupportEvent()
+    object HideReportDialog : SupportEvent()
+    data class UpdateReportReason(val reason: String) : SupportEvent()
+    data class ConfirmReport(val commentId: String, val reason: String) : SupportEvent()
 }


### PR DESCRIPTION
This commit introduces a new report feature for support comments, allowing users to flag inappropriate content.

**Key changes:**

- **Report Functionality:**
    - Added a "Report" option to the comment menu.
    - Implemented a report confirmation dialog where users can select a reason for reporting.
    - `SupportViewModel` now handles report events, including showing/hiding the dialog, updating the report reason, and confirming the report.
    - `CommunityRepositoryImpl` and `CommunityRepository` have been updated to include a `reportComment` method and `getUserLikedComments`.
    - `SupportScreen` now displays the report confirmation dialog and handles report-related UI events.
- **UI Enhancements:**
    - Improved the comment menu in `EnhancedSupportCommentCard`.
    - The "Reply" option has been removed from the comment menu as it's redundant with the "Send Support" FAB.
    - Fixed the display of support level stars in `EnhancedSupportCommentCard`.
- **State Management:**
    - `SupportUiState` now includes state variables for managing the report dialog (visibility, selected comment, report reason) and the comment menu.
    - `SupportEvent` has new events for showing/hiding the comment menu and report dialog, updating the report reason, and confirming reports.
- **Backend Interaction:**
    - The `reportComment` method in `SupportViewModel` now shows a loading state during the reporting process.
    - The `checkAndUpdateLikeStatus` method in `SupportViewModel` now correctly fetches and updates the like status of comments from the repository.
    - `CommunityRepositoryImpl` now fetches liked comments for a user.